### PR TITLE
DEV-030-Batch-5-Metrics-&-Tracking-(34,-74,-111)

### DIFF
--- a/RAG_IMPLEMENTATION_PLAN.md
+++ b/RAG_IMPLEMENTATION_PLAN.md
@@ -31,10 +31,10 @@ We'll implement the 135 RAG steps using a phased approach, starting with simple 
 - **Step 33**: Confidence check - Threshold comparison ✅
 - **Step 42**: Classification confidence - Check existence & threshold ✅
 
-### Batch 5: Metrics & Tracking (34, 74, 111)
-- **Step 34**: Track classification metrics - Metrics service call
-- **Step 74**: Track API usage - Usage tracker call
-- **Step 111**: Collect usage metrics - Aggregate metrics
+### Batch 5: Metrics & Tracking (34, 74, 111) ✅ COMPLETED
+- **Step 34**: Track classification metrics - Metrics service call ✅
+- **Step 74**: Track API usage - Usage tracker call ✅
+- **Step 111**: Collect usage metrics - Aggregate metrics ✅
 
 ## Phase 3: Caching System (Days 5-6)
 **Complex - Redis integration**
@@ -124,12 +124,17 @@ We'll implement the 135 RAG steps using a phased approach, starting with simple 
   - ✅ **Step 33**: Configurable confidence threshold validation (11 tests)
   - ✅ **Step 42**: Classification existence + 0.6 confidence check (11 tests)
   - ✅ **Total**: 42 comprehensive tests, 100% pass rate, full async orchestration
+- Batch 5: Metrics & Tracking (34, 74, 111) - Complete metrics collection and usage tracking
+  - ✅ **Step 34**: Async classification metrics tracking with monitoring infrastructure (10 tests)
+  - ✅ **Step 74**: API usage tracking with LLM token/cost monitoring and format compatibility (10 tests)
+  - ✅ **Step 111**: Usage metrics collection with user/system aggregation and environment-aware reporting (10 tests)
+  - ✅ **Total**: 30 comprehensive tests, 100% pass rate, full metrics infrastructure integration
 
-**Next Target:** Batch 5: Metrics & Tracking (34, 74, 111)
-1. Pick GitHub issues for Steps 34, 74, 111
-2. Implement metrics collection orchestrators
-3. Integrate with usage tracking services
-4. Build comprehensive analytics and monitoring
+**Next Target:** Batch 6: Cache Operations (59, 61, 62, 63, 65, 66, 68)
+1. Pick GitHub issues for cache-related steps
+2. Implement Redis cache orchestrators
+3. Integrate with caching services
+4. Build cache hit/miss tracking and optimization
 
 ## GitHub Issues Reference
 
@@ -158,9 +163,9 @@ Each issue contains:
   - ✅ **Batch 1**: Steps 44, 45, 46, 47 (Prompting)
   - ✅ **Batch 2**: Steps 10, 103, 110 (Platform)
   - ✅ **Batch 3**: Steps 3, 9, 13 (Simple Decisions)
-- [⏳] Phase 2: Classification (Steps 31, 32, 33, 34, 42, 74, 111) - **IN PROGRESS**
+- [✅] Phase 2: Classification (Steps 31, 32, 33, 34, 42, 74, 111) - **COMPLETED**
   - ✅ **Batch 4**: Steps 31, 32, 33, 42 (Classification Flow) - **COMPLETED**
-  - ⏳ **Batch 5**: Steps 34, 74, 111 (Metrics & Tracking) - **NEXT**
+  - ✅ **Batch 5**: Steps 34, 74, 111 (Metrics & Tracking) - **COMPLETED**
 - [ ] Phase 3: Caching (Steps 59, 61, 62, 63, 65, 66, 68)
 - [ ] Phase 4: Providers (Steps 48-58)
 - [ ] Phase 5: Documents (Steps 87-97)

--- a/app/orchestrators/metrics.py
+++ b/app/orchestrators/metrics.py
@@ -11,59 +11,437 @@ except Exception:  # pragma: no cover
     def rag_step_log(**kwargs): return None
     def rag_step_timer(*args, **kwargs): return nullcontext()
 
-def step_34__track_metrics(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
+async def step_34__track_metrics(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
     """
     RAG STEP 34 — ClassificationMetrics.track Record metrics
     ID: RAG.metrics.classificationmetrics.track.record.metrics
     Type: process | Category: metrics | Node: TrackMetrics
 
-    TODO: Implement orchestration so this node *changes/validates control flow/data*
-    according to Mermaid — not logs-only. Call into existing services/factories here.
+    Tracks classification metrics using the existing monitoring infrastructure.
+    This orchestrator coordinates with track_classification_usage for metrics recording.
     """
-    with rag_step_timer(34, 'RAG.metrics.classificationmetrics.track.record.metrics', 'TrackMetrics', stage="start"):
-        rag_step_log(step=34, step_id='RAG.metrics.classificationmetrics.track.record.metrics', node_label='TrackMetrics',
-                     category='metrics', type='process', stub=True, processing_stage="started")
-        # TODO: call real service/factory here and return its output
-        result = kwargs.get("result")  # placeholder
-        rag_step_log(step=34, step_id='RAG.metrics.classificationmetrics.track.record.metrics', node_label='TrackMetrics',
-                     processing_stage="completed")
-        return result
+    from app.core.logging import logger
+    from app.core.monitoring.metrics import track_classification_usage
+    from app.services.domain_action_classifier import DomainActionClassification
+    from datetime import datetime
 
-def step_74__track_usage(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
+    with rag_step_timer(34, 'RAG.metrics.classificationmetrics.track.record.metrics', 'TrackMetrics', stage="start"):
+        # Extract context parameters
+        classification = kwargs.get('classification') or (ctx or {}).get('classification')
+        prompt_used = kwargs.get('prompt_used') or (ctx or {}).get('prompt_used', False)
+
+        # Initialize metrics tracking data
+        metrics_tracked = False
+        domain = None
+        action = None
+        confidence = 0.0
+        fallback_used = False
+        error = None
+
+        try:
+            if not classification:
+                error = 'No classification data provided'
+                raise ValueError(error)
+
+            # Extract classification details
+            if isinstance(classification, DomainActionClassification):
+                domain = classification.domain.value if classification.domain else None
+                action = classification.action.value if classification.action else None
+                confidence = classification.confidence
+                fallback_used = classification.fallback_used
+            elif isinstance(classification, dict):
+                domain_obj = classification.get('domain')
+                action_obj = classification.get('action')
+                domain = domain_obj.value if hasattr(domain_obj, 'value') else str(domain_obj) if domain_obj else None
+                action = action_obj.value if hasattr(action_obj, 'value') else str(action_obj) if action_obj else None
+                confidence = classification.get('confidence', 0.0)
+                fallback_used = classification.get('fallback_used', False)
+
+            # Track classification usage
+            track_classification_usage(
+                domain=domain,
+                action=action,
+                confidence=confidence,
+                fallback_used=fallback_used,
+                prompt_used=prompt_used
+            )
+
+            metrics_tracked = True
+
+        except Exception as e:
+            error = str(e)
+
+        # Create metrics tracking result
+        metrics_data = {
+            'timestamp': datetime.utcnow().isoformat() + 'Z',
+            'metrics_tracked': metrics_tracked,
+            'domain': domain,
+            'action': action,
+            'confidence': confidence,
+            'fallback_used': fallback_used,
+            'prompt_used': prompt_used,
+            'error': error
+        }
+
+        # Log metrics tracking result
+        if error:
+            log_message = f"Classification metrics tracking failed: {error}"
+            logger.error(log_message, extra={
+                'metrics_event': 'classification_tracking_failed',
+                'error': error,
+                'prompt_used': prompt_used
+            })
+        elif confidence < 0.5:
+            log_message = f"Low confidence classification tracked: {domain}/{action} (confidence: {confidence:.3f})"
+            logger.warning(log_message, extra={
+                'metrics_event': 'low_confidence_classification_tracked',
+                'domain': domain,
+                'action': action,
+                'confidence': confidence,
+                'fallback_used': fallback_used,
+                'prompt_used': prompt_used
+            })
+        else:
+            log_message = f"Classification metrics tracked successfully: {domain}/{action}"
+            logger.info(log_message, extra={
+                'metrics_event': 'classification_tracked',
+                'domain': domain,
+                'action': action,
+                'confidence': confidence,
+                'fallback_used': fallback_used,
+                'prompt_used': prompt_used
+            })
+
+        # RAG step logging
+        rag_step_log(
+            step=34,
+            step_id='RAG.metrics.classificationmetrics.track.record.metrics',
+            node_label='TrackMetrics',
+            category='metrics',
+            type='process',
+            metrics_event='classification_tracking_failed' if error else 'classification_tracked',
+            metrics_tracked=metrics_tracked,
+            domain=domain,
+            action=action,
+            confidence=confidence,
+            fallback_used=fallback_used,
+            prompt_used=prompt_used,
+            error=error,
+            processing_stage="completed"
+        )
+
+        return metrics_data
+
+async def step_74__track_usage(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
     """
     RAG STEP 74 — UsageTracker.track Track API usage
     ID: RAG.metrics.usagetracker.track.track.api.usage
     Type: process | Category: metrics | Node: TrackUsage
 
-    TODO: Implement orchestration so this node *changes/validates control flow/data*
-    according to Mermaid — not logs-only. Call into existing services/factories here.
+    Tracks API usage using the existing UsageTracker infrastructure.
+    This orchestrator coordinates with usage_tracker for API cost and token tracking.
     """
-    with rag_step_timer(74, 'RAG.metrics.usagetracker.track.track.api.usage', 'TrackUsage', stage="start"):
-        rag_step_log(step=74, step_id='RAG.metrics.usagetracker.track.track.api.usage', node_label='TrackUsage',
-                     category='metrics', type='process', stub=True, processing_stage="started")
-        # TODO: call real service/factory here and return its output
-        result = kwargs.get("result")  # placeholder
-        rag_step_log(step=74, step_id='RAG.metrics.usagetracker.track.track.api.usage', node_label='TrackUsage',
-                     processing_stage="completed")
-        return result
+    from app.core.logging import logger
+    from app.services.usage_tracker import usage_tracker
+    from datetime import datetime
 
-def step_111__collect_metrics(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
+    with rag_step_timer(74, 'RAG.metrics.usagetracker.track.track.api.usage', 'TrackUsage', stage="start"):
+        # Extract context parameters
+        user_id = kwargs.get('user_id') or (ctx or {}).get('user_id')
+        session_id = kwargs.get('session_id') or (ctx or {}).get('session_id')
+        provider = kwargs.get('provider') or (ctx or {}).get('provider')
+        model = kwargs.get('model') or (ctx or {}).get('model')
+        llm_response = kwargs.get('llm_response') or (ctx or {}).get('llm_response')
+        response_time_ms = kwargs.get('response_time_ms') or (ctx or {}).get('response_time_ms', 0)
+        cache_hit = kwargs.get('cache_hit') or (ctx or {}).get('cache_hit', False)
+        pii_detected = kwargs.get('pii_detected') or (ctx or {}).get('pii_detected', False)
+        pii_types = kwargs.get('pii_types') or (ctx or {}).get('pii_types')
+        ip_address = kwargs.get('ip_address') or (ctx or {}).get('ip_address')
+        user_agent = kwargs.get('user_agent') or (ctx or {}).get('user_agent')
+
+        # Initialize usage tracking data
+        usage_tracked = False
+        total_tokens = 0
+        cost = 0.0
+        error = None
+
+        try:
+            # Validate required fields
+            if not all([user_id, session_id, provider, model, llm_response]):
+                error = 'Missing required usage tracking data'
+                raise ValueError(error)
+
+            # Extract token and cost information
+            if hasattr(llm_response, 'tokens_used') and llm_response.tokens_used:
+                if isinstance(llm_response.tokens_used, int):
+                    total_tokens = llm_response.tokens_used
+                elif isinstance(llm_response.tokens_used, dict):
+                    total_tokens = llm_response.tokens_used.get('input', 0) + llm_response.tokens_used.get('output', 0)
+                else:
+                    total_tokens = llm_response.tokens_used
+            if hasattr(llm_response, 'cost_estimate'):
+                cost = llm_response.cost_estimate or 0.0
+
+            # Handle token format compatibility for UsageTracker
+            # UsageTracker expects tokens_used to be a dict with 'input' and 'output' keys
+            original_tokens = llm_response.tokens_used
+            if isinstance(original_tokens, int):
+                # Convert int format to dict format expected by UsageTracker
+                # Split tokens roughly 60/40 input/output as a reasonable approximation
+                input_tokens = int(original_tokens * 0.6)
+                output_tokens = original_tokens - input_tokens
+                llm_response.tokens_used = {'input': input_tokens, 'output': output_tokens}
+
+            try:
+                # Track LLM usage
+                usage_event = await usage_tracker.track_llm_usage(
+                    user_id=user_id,
+                    session_id=session_id,
+                    provider=provider,
+                    model=model,
+                    llm_response=llm_response,
+                    response_time_ms=response_time_ms,
+                    cache_hit=cache_hit,
+                    pii_detected=pii_detected,
+                    pii_types=pii_types,
+                    ip_address=ip_address,
+                    user_agent=user_agent
+                )
+            finally:
+                # Restore original tokens format
+                llm_response.tokens_used = original_tokens
+
+            usage_tracked = True
+
+        except Exception as e:
+            error = str(e)
+
+        # Create usage tracking result
+        usage_data = {
+            'timestamp': datetime.utcnow().isoformat() + 'Z',
+            'usage_tracked': usage_tracked,
+            'user_id': user_id,
+            'session_id': session_id,
+            'provider': provider,
+            'model': model,
+            'total_tokens': total_tokens,
+            'cost': cost,
+            'cache_hit': cache_hit,
+            'pii_detected': pii_detected,
+            'response_time_ms': response_time_ms,
+            'error': error
+        }
+
+        # Log usage tracking result
+        if error:
+            log_message = f"API usage tracking failed: {error}"
+            logger.error(log_message, extra={
+                'usage_event': 'api_usage_tracking_failed',
+                'error': error,
+                'user_id': user_id,
+                'provider': provider,
+                'model': model
+            })
+        elif cost > 0.05:  # High cost threshold
+            log_message = f"High-cost API usage tracked: {provider}/{model} (cost: €{cost:.4f})"
+            logger.warning(log_message, extra={
+                'usage_event': 'high_cost_api_usage_tracked',
+                'user_id': user_id,
+                'provider': provider,
+                'model': model,
+                'cost': cost,
+                'total_tokens': total_tokens,
+                'cache_hit': cache_hit,
+                'response_time_ms': response_time_ms
+            })
+        else:
+            log_message = f"API usage tracked successfully: {provider}/{model}"
+            logger.info(log_message, extra={
+                'usage_event': 'api_usage_tracked',
+                'user_id': user_id,
+                'provider': provider,
+                'model': model,
+                'cost': cost,
+                'total_tokens': total_tokens,
+                'cache_hit': cache_hit,
+                'pii_detected': pii_detected,
+                'response_time_ms': response_time_ms
+            })
+
+        # RAG step logging
+        rag_step_log(
+            step=74,
+            step_id='RAG.metrics.usagetracker.track.track.api.usage',
+            node_label='TrackUsage',
+            category='metrics',
+            type='process',
+            usage_event='api_usage_tracking_failed' if error else 'api_usage_tracked',
+            usage_tracked=usage_tracked,
+            user_id=user_id,
+            provider=provider,
+            model=model,
+            total_tokens=total_tokens,
+            cost=cost,
+            cache_hit=cache_hit,
+            pii_detected=pii_detected,
+            response_time_ms=response_time_ms,
+            error=error,
+            processing_stage="completed"
+        )
+
+        return usage_data
+
+async def step_111__collect_metrics(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
     """
     RAG STEP 111 — Collect usage metrics
     ID: RAG.metrics.collect.usage.metrics
     Type: process | Category: metrics | Node: CollectMetrics
 
-    TODO: Implement orchestration so this node *changes/validates control flow/data*
-    according to Mermaid — not logs-only. Call into existing services/factories here.
+    Collects usage metrics for the completed query/session and aggregates system-wide metrics.
+    This orchestrator coordinates with MetricsService and UsageTracker for comprehensive metrics collection.
     """
+    from app.core.logging import logger
+    from app.services.metrics_service import MetricsService, Environment
+    from app.services.usage_tracker import usage_tracker
+    from datetime import datetime, timedelta
+
     with rag_step_timer(111, 'RAG.metrics.collect.usage.metrics', 'CollectMetrics', stage="start"):
-        rag_step_log(step=111, step_id='RAG.metrics.collect.usage.metrics', node_label='CollectMetrics',
-                     category='metrics', type='process', stub=True, processing_stage="started")
-        # TODO: call real service/factory here and return its output
-        result = kwargs.get("result")  # placeholder
-        rag_step_log(step=111, step_id='RAG.metrics.collect.usage.metrics', node_label='CollectMetrics',
-                     processing_stage="completed")
-        return result
+        # Extract context parameters
+        user_id = kwargs.get('user_id') or (ctx or {}).get('user_id')
+        session_id = kwargs.get('session_id') or (ctx or {}).get('session_id')
+        response_time_ms = kwargs.get('response_time_ms') or (ctx or {}).get('response_time_ms')
+        cache_hit = kwargs.get('cache_hit') or (ctx or {}).get('cache_hit', False)
+        provider = kwargs.get('provider') or (ctx or {}).get('provider')
+        model = kwargs.get('model') or (ctx or {}).get('model')
+        total_tokens = kwargs.get('total_tokens') or (ctx or {}).get('total_tokens', 0)
+        cost = kwargs.get('cost') or (ctx or {}).get('cost', 0.0)
+        environment_str = kwargs.get('environment') or (ctx or {}).get('environment', 'development')
+
+        # Initialize metrics collection data
+        metrics_collected = False
+        user_metrics = None
+        system_metrics = None
+        metrics_report = None
+        error = None
+
+        try:
+            # Determine environment
+            if environment_str.lower() == 'production':
+                environment = Environment.PRODUCTION
+            elif environment_str.lower() == 'staging':
+                environment = Environment.STAGING
+            else:
+                environment = Environment.DEVELOPMENT
+
+            # Collect user-specific metrics if user_id is available
+            if user_id:
+                end_time = datetime.utcnow()
+                start_time = end_time - timedelta(hours=24)  # Last 24 hours
+                user_metrics = await usage_tracker.get_user_metrics(
+                    user_id=user_id,
+                    start_date=start_time,
+                    end_date=end_time
+                )
+
+            # Collect system-wide metrics
+            end_time = datetime.utcnow()
+            start_time = end_time - timedelta(hours=1)  # Last hour
+            system_metrics = await usage_tracker.get_system_metrics(
+                start_date=start_time,
+                end_date=end_time
+            )
+
+            # Generate overall metrics report
+            metrics_service = MetricsService()
+            metrics_report = await metrics_service.generate_metrics_report(environment)
+
+            metrics_collected = True
+
+        except Exception as e:
+            error = str(e)
+
+        # Create metrics collection result
+        metrics_data = {
+            'timestamp': datetime.utcnow().isoformat() + 'Z',
+            'metrics_collected': metrics_collected,
+            'user_id': user_id,
+            'session_id': session_id,
+            'response_time_ms': response_time_ms,
+            'cache_hit': cache_hit,
+            'provider': provider,
+            'model': model,
+            'total_tokens': total_tokens,
+            'cost': cost,
+            'environment': environment_str,
+            'user_metrics_available': user_metrics is not None,
+            'system_metrics_available': system_metrics is not None,
+            'metrics_report_available': metrics_report is not None,
+            'error': error
+        }
+
+        # Add summary information if available
+        if user_metrics:
+            metrics_data['user_metrics_summary'] = {
+                'total_requests': getattr(user_metrics, 'total_requests', 0),
+                'total_cost_eur': getattr(user_metrics, 'total_cost_eur', 0.0),
+                'cache_hit_rate': getattr(user_metrics, 'cache_hit_rate', 0.0)
+            }
+
+        if system_metrics:
+            metrics_data['system_metrics_summary'] = {
+                'total_requests': getattr(system_metrics, 'total_requests', 0),
+                'avg_response_time_ms': getattr(system_metrics, 'avg_response_time_ms', 0.0),
+                'error_rate': getattr(system_metrics, 'error_rate', 0.0)
+            }
+
+        if metrics_report:
+            metrics_data['health_score'] = getattr(metrics_report, 'overall_health_score', 0.0)
+            metrics_data['alerts_count'] = len(getattr(metrics_report, 'alerts', []))
+
+        # Log metrics collection result
+        if error:
+            log_message = f"Metrics collection failed: {error}"
+            logger.error(log_message, extra={
+                'metrics_event': 'collection_failed',
+                'error': error,
+                'user_id': user_id,
+                'environment': environment_str
+            })
+        else:
+            log_message = f"Metrics collected successfully for environment: {environment_str}"
+            logger.info(log_message, extra={
+                'metrics_event': 'collection_successful',
+                'user_id': user_id,
+                'environment': environment_str,
+                'user_metrics_available': user_metrics is not None,
+                'system_metrics_available': system_metrics is not None,
+                'metrics_report_available': metrics_report is not None,
+                'cache_hit': cache_hit,
+                'response_time_ms': response_time_ms
+            })
+
+        # RAG step logging
+        rag_step_log(
+            step=111,
+            step_id='RAG.metrics.collect.usage.metrics',
+            node_label='CollectMetrics',
+            category='metrics',
+            type='process',
+            metrics_event='collection_failed' if error else 'collection_successful',
+            metrics_collected=metrics_collected,
+            user_id=user_id,
+            session_id=session_id,
+            environment=environment_str,
+            user_metrics_available=user_metrics is not None,
+            system_metrics_available=system_metrics is not None,
+            metrics_report_available=metrics_report is not None,
+            cache_hit=cache_hit,
+            response_time_ms=response_time_ms,
+            error=error,
+            processing_stage="completed"
+        )
+
+        return metrics_data
 
 def step_119__expert_feedback_collector(*, messages: Optional[List[Any]] = None, ctx: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
     """

--- a/tests/test_rag_step_111_collect_metrics.py
+++ b/tests/test_rag_step_111_collect_metrics.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+Tests for RAG STEP 111 — Collect usage metrics
+
+This step collects usage metrics for completed queries and aggregates system-wide metrics.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from app.orchestrators.metrics import step_111__collect_metrics
+from app.services.metrics_service import Environment, MetricResult, MetricsReport, MetricStatus
+
+
+class TestRAGStep111CollectMetrics:
+    """Test suite for RAG STEP 111 - Collect usage metrics"""
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_collect_successful_metrics(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Successful metrics collection"""
+
+        # Mock user metrics
+        mock_user_metrics = MagicMock()
+        mock_user_metrics.total_requests = 25
+        mock_user_metrics.total_cost_eur = 0.15
+        mock_user_metrics.cache_hit_rate = 0.75
+        mock_usage_tracker.get_user_metrics = AsyncMock(return_value=mock_user_metrics)
+
+        # Mock system metrics
+        mock_system_metrics = MagicMock()
+        mock_system_metrics.total_requests = 1500
+        mock_system_metrics.avg_response_time_ms = 320.5
+        mock_system_metrics.error_rate = 0.02
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=mock_system_metrics)
+
+        # Mock metrics report
+        mock_metrics_report = MetricsReport(
+            environment=Environment.DEVELOPMENT,
+            timestamp=datetime.utcnow(),
+            technical_metrics=[
+                MetricResult(
+                    name="API Response Time",
+                    value=320.5,
+                    target=500.0,
+                    status=MetricStatus.PASS,
+                    unit="ms",
+                    description="API response time",
+                    timestamp=datetime.utcnow(),
+                    environment=Environment.DEVELOPMENT
+                )
+            ],
+            business_metrics=[],
+            overall_health_score=0.92,
+            alerts=[],
+            recommendations=[]
+        )
+
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(return_value=mock_metrics_report)
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'response_time_ms': 320,
+            'cache_hit': True,
+            'provider': 'openai',
+            'model': 'gpt-4',
+            'total_tokens': 150,
+            'cost': 0.003,
+            'environment': 'development'
+        }
+
+        # Call the orchestrator function
+        result = await step_111__collect_metrics(ctx=ctx)
+
+        # Verify the result structure
+        assert isinstance(result, dict)
+        assert result['metrics_collected'] is True
+        assert result['user_id'] == 'user_123'
+        assert result['session_id'] == 'session_456'
+        assert result['environment'] == 'development'
+        assert result['user_metrics_available'] is True
+        assert result['system_metrics_available'] is True
+        assert result['metrics_report_available'] is True
+        assert result['health_score'] == 0.92
+        assert result['alerts_count'] == 0
+        assert 'timestamp' in result
+
+        # Verify user metrics summary
+        assert 'user_metrics_summary' in result
+        assert result['user_metrics_summary']['total_requests'] == 25
+        assert result['user_metrics_summary']['total_cost_eur'] == 0.15
+        assert result['user_metrics_summary']['cache_hit_rate'] == 0.75
+
+        # Verify system metrics summary
+        assert 'system_metrics_summary' in result
+        assert result['system_metrics_summary']['total_requests'] == 1500
+        assert result['system_metrics_summary']['avg_response_time_ms'] == 320.5
+        assert result['system_metrics_summary']['error_rate'] == 0.02
+
+        # Verify services were called correctly
+        mock_usage_tracker.get_user_metrics.assert_called_once()
+        user_call_args = mock_usage_tracker.get_user_metrics.call_args
+        assert user_call_args[1]['user_id'] == 'user_123'
+        assert isinstance(user_call_args[1]['start_date'], datetime)
+        assert isinstance(user_call_args[1]['end_date'], datetime)
+
+        mock_usage_tracker.get_system_metrics.assert_called_once()
+        system_call_args = mock_usage_tracker.get_system_metrics.call_args
+        assert isinstance(system_call_args[1]['start_date'], datetime)
+        assert isinstance(system_call_args[1]['end_date'], datetime)
+
+        mock_metrics_service.generate_metrics_report.assert_called_once_with(Environment.DEVELOPMENT)
+
+        # Verify logging was called
+        mock_logger.info.assert_called_once()
+        log_call = mock_logger.info.call_args
+        assert 'Metrics collected successfully' in log_call[0][0]
+        assert log_call[1]['extra']['metrics_event'] == 'collection_successful'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_collect_without_user_id(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Metrics collection without user ID"""
+
+        # Mock system metrics only (no user metrics)
+        mock_system_metrics = MagicMock()
+        mock_system_metrics.total_requests = 500
+        mock_system_metrics.avg_response_time_ms = 280.0
+        mock_system_metrics.error_rate = 0.01
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=mock_system_metrics)
+
+        # Mock metrics report
+        mock_metrics_report = MagicMock()
+        mock_metrics_report.overall_health_score = 0.88
+        mock_metrics_report.alerts = ['Warning: High response time']
+
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(return_value=mock_metrics_report)
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        ctx = {
+            'session_id': 'session_789',
+            'response_time_ms': 450,
+            'cache_hit': False,
+            'environment': 'production'
+        }
+
+        result = await step_111__collect_metrics(ctx=ctx)
+
+        assert result['metrics_collected'] is True
+        assert result['user_id'] is None
+        assert result['user_metrics_available'] is False
+        assert result['system_metrics_available'] is True
+        assert result['metrics_report_available'] is True
+        assert result['health_score'] == 0.88
+        assert result['alerts_count'] == 1
+
+        # Should not have user metrics summary
+        assert 'user_metrics_summary' not in result
+
+        # Should have system metrics summary
+        assert 'system_metrics_summary' in result
+        assert result['system_metrics_summary']['total_requests'] == 500
+
+        # Verify user metrics not called
+        mock_usage_tracker.get_user_metrics.assert_not_called()
+        # System metrics should still be called
+        mock_usage_tracker.get_system_metrics.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_environment_handling(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Different environment handling"""
+
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=MagicMock())
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(return_value=MagicMock())
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        # Test production environment
+        result = await step_111__collect_metrics(environment='production')
+        mock_metrics_service.generate_metrics_report.assert_called_with(Environment.PRODUCTION)
+
+        # Test staging environment
+        result = await step_111__collect_metrics(environment='staging')
+        mock_metrics_service.generate_metrics_report.assert_called_with(Environment.STAGING)
+
+        # Test default to development
+        result = await step_111__collect_metrics(environment='unknown')
+        mock_metrics_service.generate_metrics_report.assert_called_with(Environment.DEVELOPMENT)
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_usage_tracker_error(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Handle usage tracker service error"""
+
+        mock_usage_tracker.get_user_metrics = AsyncMock(side_effect=Exception("Database connection error"))
+        mock_usage_tracker.get_system_metrics = AsyncMock(side_effect=Exception("Database connection error"))
+
+        ctx = {
+            'user_id': 'user_123',
+            'environment': 'development'
+        }
+
+        result = await step_111__collect_metrics(ctx=ctx)
+
+        # Should return error result
+        assert result['metrics_collected'] is False
+        assert result['error'] == 'Database connection error'
+        assert result['user_metrics_available'] is False
+        assert result['system_metrics_available'] is False
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call = mock_logger.error.call_args
+        assert 'Metrics collection failed' in error_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_metrics_service_error(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Handle metrics service error"""
+
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=MagicMock())
+
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(side_effect=Exception("Metrics service error"))
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        ctx = {'environment': 'development'}
+
+        result = await step_111__collect_metrics(ctx=ctx)
+
+        assert result['metrics_collected'] is False
+        assert result['error'] == 'Metrics service error'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_kwargs_parameters(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Parameters passed via kwargs"""
+
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=MagicMock())
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(return_value=MagicMock())
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        # Call with kwargs instead of ctx
+        result = await step_111__collect_metrics(
+            user_id='user_456',
+            session_id='session_789',
+            response_time_ms=200,
+            cache_hit=True,
+            environment='staging'
+        )
+
+        # Verify kwargs are processed correctly
+        assert result['user_id'] == 'user_456'
+        assert result['session_id'] == 'session_789'
+        assert result['response_time_ms'] == 200
+        assert result['cache_hit'] is True
+        assert result['environment'] == 'staging'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_performance_tracking(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Performance tracking with timer"""
+
+        with patch('app.orchestrators.metrics.rag_step_timer') as mock_timer:
+            # Mock the timer context manager
+            mock_timer.return_value.__enter__ = MagicMock()
+            mock_timer.return_value.__exit__ = MagicMock()
+
+            mock_usage_tracker.get_system_metrics = AsyncMock(return_value=MagicMock())
+            mock_metrics_service = MagicMock()
+            mock_metrics_service.generate_metrics_report = AsyncMock(return_value=MagicMock())
+            mock_metrics_service_class.return_value = mock_metrics_service
+
+            # Call the orchestrator function
+            await step_111__collect_metrics(ctx={'environment': 'development'})
+
+            # Verify timer was used
+            mock_timer.assert_called_with(
+                111,
+                'RAG.metrics.collect.usage.metrics',
+                'CollectMetrics',
+                stage='start'
+            )
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_comprehensive_logging_format(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Verify comprehensive logging format"""
+
+        mock_usage_tracker.get_user_metrics = AsyncMock(return_value=MagicMock())
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=MagicMock())
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(return_value=MagicMock())
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        ctx = {
+            'user_id': 'user_123',
+            'environment': 'development'
+        }
+
+        # Call the orchestrator function
+        await step_111__collect_metrics(ctx=ctx)
+
+        # Verify RAG step logging format
+        completed_logs = [
+            call for call in mock_rag_log.call_args_list
+            if call[1].get('processing_stage') == 'completed'
+        ]
+
+        assert len(completed_logs) > 0
+        log_call = completed_logs[0]
+
+        # Check required fields
+        required_fields = [
+            'step', 'step_id', 'node_label', 'metrics_event',
+            'metrics_collected', 'user_id', 'environment',
+            'user_metrics_available', 'system_metrics_available',
+            'metrics_report_available', 'processing_stage'
+        ]
+
+        for field in required_fields:
+            assert field in log_call[1], f"Missing required field: {field}"
+
+        # Verify specific values
+        assert log_call[1]['step'] == 111
+        assert log_call[1]['step_id'] == 'RAG.metrics.collect.usage.metrics'
+        assert log_call[1]['node_label'] == 'CollectMetrics'
+        assert log_call[1]['metrics_event'] == 'collection_successful'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_metrics_data_structure(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Verify metrics data structure"""
+
+        mock_usage_tracker.get_user_metrics = AsyncMock(return_value=MagicMock())
+        mock_usage_tracker.get_system_metrics = AsyncMock(return_value=MagicMock())
+        mock_metrics_service = MagicMock()
+        mock_metrics_service.generate_metrics_report = AsyncMock(return_value=MagicMock())
+        mock_metrics_service_class.return_value = mock_metrics_service
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'environment': 'development'
+        }
+
+        # Call the orchestrator function
+        result = await step_111__collect_metrics(ctx=ctx)
+
+        # Verify all expected fields in result
+        expected_fields = [
+            'timestamp', 'metrics_collected', 'user_id', 'session_id',
+            'response_time_ms', 'cache_hit', 'provider', 'model',
+            'total_tokens', 'cost', 'environment', 'user_metrics_available',
+            'system_metrics_available', 'metrics_report_available', 'error'
+        ]
+
+        for field in expected_fields:
+            assert field in result, f"Missing field in metrics data: {field}"
+
+        # Verify data types
+        assert isinstance(result['timestamp'], str)
+        assert isinstance(result['metrics_collected'], bool)
+        assert isinstance(result['user_id'], str) or result['user_id'] is None
+        assert isinstance(result['session_id'], str) or result['session_id'] is None
+        assert isinstance(result['response_time_ms'], int) or result['response_time_ms'] is None
+        assert isinstance(result['cache_hit'], bool)
+        assert isinstance(result['environment'], str)
+        assert isinstance(result['user_metrics_available'], bool)
+        assert isinstance(result['system_metrics_available'], bool)
+        assert isinstance(result['metrics_report_available'], bool)
+
+        # Verify timestamp format (ISO format)
+        datetime.fromisoformat(result['timestamp'].replace('Z', '+00:00'))
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.metrics_service.MetricsService')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_111_partial_failures(self, mock_usage_tracker, mock_metrics_service_class, mock_logger, mock_rag_log):
+        """Test Step 111: Handle partial service failures gracefully"""
+
+        # User metrics succeeds, system metrics fails
+        mock_user_metrics = MagicMock()
+        mock_usage_tracker.get_user_metrics = AsyncMock(return_value=mock_user_metrics)
+        mock_usage_tracker.get_system_metrics = AsyncMock(side_effect=Exception("System metrics error"))
+
+        ctx = {
+            'user_id': 'user_123',
+            'environment': 'development'
+        }
+
+        result = await step_111__collect_metrics(ctx=ctx)
+
+        # Should fail overall due to exception
+        assert result['metrics_collected'] is False
+        assert result['error'] == 'System metrics error'

--- a/tests/test_rag_step_34_track_metrics.py
+++ b/tests/test_rag_step_34_track_metrics.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+Tests for RAG STEP 34 — ClassificationMetrics.track Record metrics
+
+This step tracks classification metrics using the existing monitoring infrastructure.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from app.orchestrators.metrics import step_34__track_metrics
+from app.services.domain_action_classifier import Domain, Action, DomainActionClassification
+
+
+class TestRAGStep34TrackMetrics:
+    """Test suite for RAG STEP 34 - Track classification metrics"""
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_track_classification_success(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Successful classification metrics tracking"""
+
+        classification = DomainActionClassification(
+            domain=Domain.TAX,
+            action=Action.INFORMATION_REQUEST,
+            confidence=0.85,
+            reasoning="Tax information request",
+            fallback_used=False
+        )
+
+        ctx = {
+            'classification': classification,
+            'prompt_used': True,
+            'user_query': 'Qual è l\'aliquota IVA per i servizi professionali?'
+        }
+
+        # Call the orchestrator function
+        result = await step_34__track_metrics(ctx=ctx)
+
+        # Verify the result structure
+        assert isinstance(result, dict)
+        assert result['metrics_tracked'] is True
+        assert result['domain'] == 'tax'
+        assert result['action'] == 'information_request'
+        assert result['confidence'] == 0.85
+        assert result['fallback_used'] is False
+        assert result['prompt_used'] is True
+        assert 'timestamp' in result
+
+        # Verify track_classification_usage was called correctly
+        mock_track_usage.assert_called_once_with(
+            domain='tax',
+            action='information_request',
+            confidence=0.85,
+            fallback_used=False,
+            prompt_used=True
+        )
+
+        # Verify logging was called
+        mock_logger.info.assert_called_once()
+        log_call = mock_logger.info.call_args
+        assert 'Classification metrics tracked successfully' in log_call[0][0]
+        assert log_call[1]['extra']['metrics_event'] == 'classification_tracked'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_track_with_fallback_used(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Track classification with LLM fallback"""
+
+        classification = DomainActionClassification(
+            domain=Domain.BUSINESS,
+            action=Action.STRATEGIC_ADVICE,
+            confidence=0.72,
+            reasoning="Business advice via LLM fallback",
+            fallback_used=True
+        )
+
+        ctx = {
+            'classification': classification,
+            'prompt_used': False
+        }
+
+        result = await step_34__track_metrics(ctx=ctx)
+
+        assert result['metrics_tracked'] is True
+        assert result['fallback_used'] is True
+        assert result['prompt_used'] is False
+
+        # Verify fallback usage was tracked
+        mock_track_usage.assert_called_once_with(
+            domain='business',
+            action='strategic_advice',
+            confidence=0.72,
+            fallback_used=True,
+            prompt_used=False
+        )
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_track_dict_format_classification(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Track classification provided as dict"""
+
+        ctx = {
+            'classification': {
+                'domain': Domain.LEGAL,
+                'action': Action.DOCUMENT_GENERATION,
+                'confidence': 0.91,
+                'reasoning': "Legal document generation",
+                'fallback_used': False
+            },
+            'prompt_used': True
+        }
+
+        result = await step_34__track_metrics(ctx=ctx)
+
+        assert result['metrics_tracked'] is True
+        assert result['domain'] == 'legal'
+        assert result['action'] == 'document_generation'
+
+        mock_track_usage.assert_called_once_with(
+            domain='legal',
+            action='document_generation',
+            confidence=0.91,
+            fallback_used=False,
+            prompt_used=True
+        )
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_missing_classification_data(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Handle missing classification data"""
+
+        ctx = {}
+
+        result = await step_34__track_metrics(ctx=ctx)
+
+        # Should return error result
+        assert result['metrics_tracked'] is False
+        assert result['error'] == 'No classification data provided'
+
+        # Should not call tracking
+        mock_track_usage.assert_not_called()
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call = mock_logger.error.call_args
+        assert 'Classification metrics tracking failed' in error_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_metrics_tracking_error(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Handle metrics tracking service error"""
+
+        mock_track_usage.side_effect = Exception("Metrics service error")
+
+        classification = DomainActionClassification(
+            domain=Domain.ACCOUNTING,
+            action=Action.CALCULATION_REQUEST,
+            confidence=0.88,
+            reasoning="Accounting calculation"
+        )
+
+        ctx = {
+            'classification': classification,
+            'prompt_used': False
+        }
+
+        result = await step_34__track_metrics(ctx=ctx)
+
+        # Should return error result
+        assert result['metrics_tracked'] is False
+        assert result['error'] == 'Metrics service error'
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call = mock_logger.error.call_args
+        assert 'Classification metrics tracking failed' in error_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_low_confidence_classification(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Track low confidence classification"""
+
+        classification = DomainActionClassification(
+            domain=Domain.LABOR,
+            action=Action.COMPLIANCE_CHECK,
+            confidence=0.35,
+            reasoning="Low confidence labor compliance",
+            fallback_used=True
+        )
+
+        ctx = {
+            'classification': classification,
+            'prompt_used': False
+        }
+
+        result = await step_34__track_metrics(ctx=ctx)
+
+        assert result['metrics_tracked'] is True
+        assert result['confidence'] == 0.35
+
+        # Should still track low confidence classifications
+        mock_track_usage.assert_called_once_with(
+            domain='labor',
+            action='compliance_check',
+            confidence=0.35,
+            fallback_used=True,
+            prompt_used=False
+        )
+
+        # Should log warning for low confidence
+        mock_logger.warning.assert_called_once()
+        warning_call = mock_logger.warning.call_args
+        assert 'Low confidence classification tracked' in warning_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_kwargs_parameters(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Parameters passed via kwargs"""
+
+        classification = DomainActionClassification(
+            domain=Domain.TAX,
+            action=Action.INFORMATION_REQUEST,
+            confidence=0.89,
+            reasoning="Tax information request"
+        )
+
+        # Call with kwargs instead of ctx
+        result = await step_34__track_metrics(
+            classification=classification,
+            prompt_used=True
+        )
+
+        # Verify kwargs are processed correctly
+        assert result['metrics_tracked'] is True
+        assert result['domain'] == 'tax'
+        assert result['confidence'] == 0.89
+
+        mock_track_usage.assert_called_once_with(
+            domain='tax',
+            action='information_request',
+            confidence=0.89,
+            fallback_used=False,
+            prompt_used=True
+        )
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_performance_tracking(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Performance tracking with timer"""
+
+        with patch('app.orchestrators.metrics.rag_step_timer') as mock_timer:
+            # Mock the timer context manager
+            mock_timer.return_value.__enter__ = MagicMock()
+            mock_timer.return_value.__exit__ = MagicMock()
+
+            classification = DomainActionClassification(
+                domain=Domain.TAX,
+                action=Action.INFORMATION_REQUEST,
+                confidence=0.85,
+                reasoning="Test classification"
+            )
+
+            # Call the orchestrator function
+            await step_34__track_metrics(ctx={'classification': classification})
+
+            # Verify timer was used
+            mock_timer.assert_called_with(
+                34,
+                'RAG.metrics.classificationmetrics.track.record.metrics',
+                'TrackMetrics',
+                stage='start'
+            )
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_comprehensive_logging_format(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Verify comprehensive logging format"""
+
+        classification = DomainActionClassification(
+            domain=Domain.TAX,
+            action=Action.INFORMATION_REQUEST,
+            confidence=0.85,
+            reasoning="Tax query classification"
+        )
+
+        ctx = {
+            'classification': classification,
+            'prompt_used': True
+        }
+
+        # Call the orchestrator function
+        await step_34__track_metrics(ctx=ctx)
+
+        # Verify RAG step logging format
+        completed_logs = [
+            call for call in mock_rag_log.call_args_list
+            if call[1].get('processing_stage') == 'completed'
+        ]
+
+        assert len(completed_logs) > 0
+        log_call = completed_logs[0]
+
+        # Check required fields
+        required_fields = [
+            'step', 'step_id', 'node_label', 'metrics_event',
+            'metrics_tracked', 'domain', 'action', 'confidence',
+            'fallback_used', 'prompt_used', 'processing_stage'
+        ]
+
+        for field in required_fields:
+            assert field in log_call[1], f"Missing required field: {field}"
+
+        # Verify specific values
+        assert log_call[1]['step'] == 34
+        assert log_call[1]['step_id'] == 'RAG.metrics.classificationmetrics.track.record.metrics'
+        assert log_call[1]['node_label'] == 'TrackMetrics'
+        assert log_call[1]['metrics_event'] == 'classification_tracked'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.core.monitoring.metrics.track_classification_usage')
+    async def test_step_34_metrics_data_structure(self, mock_track_usage, mock_logger, mock_rag_log):
+        """Test Step 34: Verify metrics data structure"""
+
+        classification = DomainActionClassification(
+            domain=Domain.TAX,
+            action=Action.INFORMATION_REQUEST,
+            confidence=0.85,
+            reasoning="Test classification"
+        )
+
+        ctx = {
+            'classification': classification,
+            'prompt_used': True
+        }
+
+        # Call the orchestrator function
+        result = await step_34__track_metrics(ctx=ctx)
+
+        # Verify all expected fields in result
+        expected_fields = [
+            'timestamp', 'metrics_tracked', 'domain', 'action',
+            'confidence', 'fallback_used', 'prompt_used', 'error'
+        ]
+
+        for field in expected_fields:
+            assert field in result, f"Missing field in metrics data: {field}"
+
+        # Verify data types
+        assert isinstance(result['timestamp'], str)
+        assert isinstance(result['metrics_tracked'], bool)
+        assert isinstance(result['domain'], str) or result['domain'] is None
+        assert isinstance(result['action'], str) or result['action'] is None
+        assert isinstance(result['confidence'], float)
+        assert isinstance(result['fallback_used'], bool)
+        assert isinstance(result['prompt_used'], bool)
+
+        # Verify timestamp format (ISO format)
+        datetime.fromisoformat(result['timestamp'].replace('Z', '+00:00'))

--- a/tests/test_rag_step_74_track_usage.py
+++ b/tests/test_rag_step_74_track_usage.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""
+Tests for RAG STEP 74 — UsageTracker.track Track API usage
+
+This step tracks API usage using the existing UsageTracker infrastructure.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from app.orchestrators.metrics import step_74__track_usage
+from app.core.llm.base import LLMResponse
+
+
+class TestRAGStep74TrackUsage:
+    """Test suite for RAG STEP 74 - Track API usage"""
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_track_successful_llm_usage(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Successful LLM usage tracking"""
+
+        # Mock LLM response
+        llm_response = LLMResponse(
+            content="Test response content",
+            model="gpt-4",
+            provider="openai",
+            tokens_used=150,
+            cost_estimate=0.003
+        )
+
+        # Mock usage event
+        mock_usage_event = MagicMock()
+        mock_usage_event.id = "usage_123"
+        mock_usage_event.total_cost = 0.003
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'provider': 'openai',
+            'model': 'gpt-4',
+            'llm_response': llm_response,
+            'response_time_ms': 1500,
+            'cache_hit': False,
+            'pii_detected': False
+        }
+
+        # Call the orchestrator function
+        result = await step_74__track_usage(ctx=ctx)
+
+        # Verify the result structure
+        assert isinstance(result, dict)
+        assert result['usage_tracked'] is True
+        assert result['user_id'] == 'user_123'
+        assert result['provider'] == 'openai'
+        assert result['model'] == 'gpt-4'
+        assert result['total_tokens'] == 150
+        assert result['cost'] == 0.003
+        assert result['cache_hit'] is False
+        assert result['response_time_ms'] == 1500
+        assert 'timestamp' in result
+
+        # Verify usage tracker was called correctly
+        mock_usage_tracker.track_llm_usage.assert_called_once_with(
+            user_id='user_123',
+            session_id='session_456',
+            provider='openai',
+            model='gpt-4',
+            llm_response=llm_response,
+            response_time_ms=1500,
+            cache_hit=False,
+            pii_detected=False,
+            pii_types=None,
+            ip_address=None,
+            user_agent=None
+        )
+
+        # Verify logging was called
+        mock_logger.info.assert_called_once()
+        log_call = mock_logger.info.call_args
+        assert 'API usage tracked successfully' in log_call[0][0]
+        assert log_call[1]['extra']['usage_event'] == 'api_usage_tracked'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_track_with_cache_hit(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Track usage with cache hit"""
+
+        llm_response = LLMResponse(
+            content="Cached response",
+            model="gpt-3.5-turbo",
+            provider="openai",
+            tokens_used=75,
+            cost_estimate=0.0001  # Much lower cost for cached response
+        )
+
+        mock_usage_event = MagicMock()
+        mock_usage_event.total_cost = 0.0001
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        ctx = {
+            'user_id': 'user_456',
+            'session_id': 'session_789',
+            'provider': 'openai',
+            'model': 'gpt-3.5-turbo',
+            'llm_response': llm_response,
+            'response_time_ms': 150,  # Fast cache response
+            'cache_hit': True,
+            'pii_detected': False
+        }
+
+        result = await step_74__track_usage(ctx=ctx)
+
+        assert result['usage_tracked'] is True
+        assert result['cache_hit'] is True
+        assert result['response_time_ms'] == 150
+        assert result['cost'] == 0.0001
+
+        # Verify cache hit tracking
+        mock_usage_tracker.track_llm_usage.assert_called_once()
+        call_args = mock_usage_tracker.track_llm_usage.call_args
+        assert call_args[1]['cache_hit'] is True
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_track_with_pii_detection(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Track usage with PII detection"""
+
+        llm_response = LLMResponse(
+            content="Response with anonymized data",
+            model="gpt-4",
+            provider="anthropic",
+            tokens_used=200,
+            cost_estimate=0.004
+        )
+
+        mock_usage_event = MagicMock()
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        ctx = {
+            'user_id': 'user_789',
+            'session_id': 'session_101',
+            'provider': 'anthropic',
+            'model': 'claude-3',
+            'llm_response': llm_response,
+            'response_time_ms': 2000,
+            'cache_hit': False,
+            'pii_detected': True,
+            'pii_types': ['email', 'phone'],
+            'ip_address': '192.168.1.1',
+            'user_agent': 'Mozilla/5.0'
+        }
+
+        result = await step_74__track_usage(ctx=ctx)
+
+        assert result['usage_tracked'] is True
+        assert result['pii_detected'] is True
+
+        # Verify PII tracking
+        call_args = mock_usage_tracker.track_llm_usage.call_args
+        assert call_args[1]['pii_detected'] is True
+        assert call_args[1]['pii_types'] == ['email', 'phone']
+        assert call_args[1]['ip_address'] == '192.168.1.1'
+        assert call_args[1]['user_agent'] == 'Mozilla/5.0'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_missing_required_data(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Handle missing required tracking data"""
+
+        ctx = {'user_id': 'user_123'}  # Missing other required fields
+
+        result = await step_74__track_usage(ctx=ctx)
+
+        # Should return error result
+        assert result['usage_tracked'] is False
+        assert result['error'] == 'Missing required usage tracking data'
+
+        # Should not call tracking
+        mock_usage_tracker.track_llm_usage.assert_not_called()
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call = mock_logger.error.call_args
+        assert 'API usage tracking failed' in error_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_usage_tracker_error(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Handle usage tracker service error"""
+
+        mock_usage_tracker.track_llm_usage = AsyncMock(side_effect=Exception("Usage tracking service error"))
+
+        llm_response = LLMResponse(
+            content="Test response",
+            model="gpt-4",
+            provider="openai",
+            tokens_used=100,
+            cost_estimate=0.002
+        )
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'provider': 'openai',
+            'model': 'gpt-4',
+            'llm_response': llm_response,
+            'response_time_ms': 1500
+        }
+
+        result = await step_74__track_usage(ctx=ctx)
+
+        # Should return error result
+        assert result['usage_tracked'] is False
+        assert result['error'] == 'Usage tracking service error'
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        error_call = mock_logger.error.call_args
+        assert 'API usage tracking failed' in error_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_high_cost_tracking(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Track high-cost API usage with warning"""
+
+        llm_response = LLMResponse(
+            content="Expensive response",
+            model="gpt-4",
+            provider="openai",
+            tokens_used=3500,
+            cost_estimate=0.07  # High cost
+        )
+
+        mock_usage_event = MagicMock()
+        mock_usage_event.total_cost = 0.07
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'provider': 'openai',
+            'model': 'gpt-4',
+            'llm_response': llm_response,
+            'response_time_ms': 5000,
+            'cache_hit': False
+        }
+
+        result = await step_74__track_usage(ctx=ctx)
+
+        assert result['usage_tracked'] is True
+        assert result['cost'] == 0.07
+
+        # Should log warning for high cost
+        mock_logger.warning.assert_called_once()
+        warning_call = mock_logger.warning.call_args
+        assert 'High-cost API usage tracked' in warning_call[0][0]
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_kwargs_parameters(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Parameters passed via kwargs"""
+
+        llm_response = LLMResponse(
+            content="Test response",
+            model="gpt-4",
+            provider="openai",
+            tokens_used=100,
+            cost_estimate=0.002
+        )
+
+        mock_usage_event = MagicMock()
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        # Call with kwargs instead of ctx
+        result = await step_74__track_usage(
+            user_id='user_123',
+            session_id='session_456',
+            provider='openai',
+            model='gpt-4',
+            llm_response=llm_response,
+            response_time_ms=1500
+        )
+
+        # Verify kwargs are processed correctly
+        assert result['usage_tracked'] is True
+        assert result['user_id'] == 'user_123'
+        assert result['provider'] == 'openai'
+
+        mock_usage_tracker.track_llm_usage.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_performance_tracking(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Performance tracking with timer"""
+
+        with patch('app.orchestrators.metrics.rag_step_timer') as mock_timer:
+            # Mock the timer context manager
+            mock_timer.return_value.__enter__ = MagicMock()
+            mock_timer.return_value.__exit__ = MagicMock()
+
+            llm_response = LLMResponse(content="Test", model="gpt-4", provider="openai", tokens_used=10, cost_estimate=0.001)
+
+            # Call the orchestrator function
+            await step_74__track_usage(ctx={
+                'user_id': 'user_123',
+                'session_id': 'session_456',
+                'provider': 'openai',
+                'model': 'gpt-4',
+                'llm_response': llm_response,
+                'response_time_ms': 1000
+            })
+
+            # Verify timer was used
+            mock_timer.assert_called_with(
+                74,
+                'RAG.metrics.usagetracker.track.track.api.usage',
+                'TrackUsage',
+                stage='start'
+            )
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_comprehensive_logging_format(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Verify comprehensive logging format"""
+
+        llm_response = LLMResponse(
+            content="Test response",
+            model="gpt-4",
+            provider="openai",
+            tokens_used=100,
+            cost_estimate=0.002
+        )
+
+        mock_usage_event = MagicMock()
+        mock_usage_event.total_cost = 0.002
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'provider': 'openai',
+            'model': 'gpt-4',
+            'llm_response': llm_response,
+            'response_time_ms': 1500
+        }
+
+        # Call the orchestrator function
+        await step_74__track_usage(ctx=ctx)
+
+        # Verify RAG step logging format
+        completed_logs = [
+            call for call in mock_rag_log.call_args_list
+            if call[1].get('processing_stage') == 'completed'
+        ]
+
+        assert len(completed_logs) > 0
+        log_call = completed_logs[0]
+
+        # Check required fields
+        required_fields = [
+            'step', 'step_id', 'node_label', 'usage_event',
+            'usage_tracked', 'user_id', 'provider', 'model',
+            'total_tokens', 'cost', 'cache_hit', 'processing_stage'
+        ]
+
+        for field in required_fields:
+            assert field in log_call[1], f"Missing required field: {field}"
+
+        # Verify specific values
+        assert log_call[1]['step'] == 74
+        assert log_call[1]['step_id'] == 'RAG.metrics.usagetracker.track.track.api.usage'
+        assert log_call[1]['node_label'] == 'TrackUsage'
+        assert log_call[1]['usage_event'] == 'api_usage_tracked'
+
+    @pytest.mark.asyncio
+    @patch('app.orchestrators.metrics.rag_step_log')
+    @patch('app.core.logging.logger')
+    @patch('app.services.usage_tracker.usage_tracker')
+    async def test_step_74_usage_data_structure(self, mock_usage_tracker, mock_logger, mock_rag_log):
+        """Test Step 74: Verify usage data structure"""
+
+        llm_response = LLMResponse(
+            content="Test response",
+            model="gpt-4",
+            provider="openai",
+            tokens_used=100,
+            cost_estimate=0.002
+        )
+
+        mock_usage_event = MagicMock()
+        mock_usage_event.total_cost = 0.002
+        mock_usage_tracker.track_llm_usage = AsyncMock(return_value=mock_usage_event)
+
+        ctx = {
+            'user_id': 'user_123',
+            'session_id': 'session_456',
+            'provider': 'openai',
+            'model': 'gpt-4',
+            'llm_response': llm_response,
+            'response_time_ms': 1500
+        }
+
+        # Call the orchestrator function
+        result = await step_74__track_usage(ctx=ctx)
+
+        # Verify all expected fields in result
+        expected_fields = [
+            'timestamp', 'usage_tracked', 'user_id', 'session_id',
+            'provider', 'model', 'total_tokens', 'cost',
+            'cache_hit', 'pii_detected', 'response_time_ms', 'error'
+        ]
+
+        for field in expected_fields:
+            assert field in result, f"Missing field in usage data: {field}"
+
+        # Verify data types
+        assert isinstance(result['timestamp'], str)
+        assert isinstance(result['usage_tracked'], bool)
+        assert isinstance(result['user_id'], str) or result['user_id'] is None
+        assert isinstance(result['provider'], str) or result['provider'] is None
+        assert isinstance(result['model'], str) or result['model'] is None
+        assert isinstance(result['total_tokens'], int)
+        assert isinstance(result['cost'], float)
+        assert isinstance(result['cache_hit'], bool)
+        assert isinstance(result['pii_detected'], bool)
+        assert isinstance(result['response_time_ms'], int)
+
+        # Verify timestamp format (ISO format)
+        datetime.fromisoformat(result['timestamp'].replace('Z', '+00:00'))


### PR DESCRIPTION
Implemented Batch 5 metrics and tracking orchestrators (steps 34, 74, 111)

  - Add Step 34: Track classification metrics with domain/action/confidence tracking
  - Add Step 74: Track API usage with LLM token/cost monitoring and format compatibility handling
  - Add Step 111: Collect usage metrics with user/system metrics aggregation and environment-aware reporting
  - Add comprehensive test coverage (30 tests total, 10 per step) with 100% pass rate
  - Fix token format mismatch between LLMResponse (int) and UsageTracker (dict) expectations
  - All implementations follow thin orchestrator pattern and align with RAG Mermaid diagram"